### PR TITLE
Update some of dependecies

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -507,7 +507,9 @@ export default [
       'eslint-comments/require-description': 'warn',
 
       'promise/no-multiple-resolved': 'error',
+      'promise/prefer-catch': 'error',
 
+      'import/enforce-node-protocol-usage': 'error',
       'import/consistent-type-specifier-style': ['warn', 'prefer-inline'],
       'import/newline-after-import': 'warn',
       'import/no-amd': 'error',
@@ -648,6 +650,7 @@ export default [
       '@stylistic/lines-between-class-members': 'off',
       '@stylistic/padding-line-between-statements': 'off',
       '@stylistic/no-mixed-operators': 'off',
+      '@stylistic/curly-newline': 'off',
       '@typescript-eslint/no-unnecessary-type-parameters': 'off',
       '@typescript-eslint/no-deprecated': 'off',
       '@typescript-eslint/no-restricted-types': 'off',

--- a/index.mjs
+++ b/index.mjs
@@ -243,6 +243,8 @@ export default [
       'jest/require-to-throw-message': 'error',
       'jest/require-top-level-describe': 'warn',
       'testing-library/prefer-explicit-assert': ['error', { assertion: 'toBeInTheDocument' }],
+      'testing-library/no-test-id-queries': 'error',
+      "testing-library/prefer-user-event-setup": 'error',
     },
   },
   perfectionist.configs['recommended-alphabetical'],

--- a/package.json
+++ b/package.json
@@ -17,28 +17,28 @@
     "@tanstack/eslint-plugin-query": "5.51.15",
     "@typescript-eslint/eslint-plugin": "8.31.0",
     "@typescript-eslint/parser": "8.31.0",
-    "eslint-config-prettier": "10.1.2",
-    "eslint-config-xo": "0.46.0",
+    "eslint-config-prettier": "10.1.8",
+    "eslint-config-xo": "0.49.0",
     "eslint-config-xo-typescript": "7.0.0",
     "eslint-plugin-eslint-comments": "3.2.0",
-    "eslint-plugin-import": "2.31.0",
+    "eslint-plugin-import": "2.32.0",
     "eslint-plugin-jest": "28.11.0",
     "eslint-plugin-jsx-a11y": "6.10.2",
     "eslint-plugin-perfectionist": "4.12.2",
-    "eslint-plugin-prettier": "5.2.6",
-    "eslint-plugin-promise": "7.1.0",
-    "eslint-plugin-react": "7.35.0",
+    "eslint-plugin-prettier": "5.5.5",
+    "eslint-plugin-promise": "7.2.1",
+    "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "7.0.1",
-    "eslint-plugin-regexp": "2.6.0",
-    "eslint-plugin-sonarjs": "3.0.2",
+    "eslint-plugin-regexp": "3.0.0",
+    "eslint-plugin-sonarjs": "3.0.5",
     "eslint-plugin-sort-destructure-keys": "2.0.0",
-    "eslint-plugin-testing-library": "7.1.1",
+    "eslint-plugin-testing-library": "7.15.4",
     "eslint-plugin-unicorn": "62.0.0",
     "prettier": "3.8.1",
     "prettier-plugin-curly": "0.4.1",
     "prettier-plugin-packagejson": "3.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=9.35.0"
+    "eslint": ">=9.39.2"
   }
 }


### PR DESCRIPTION
Update casti dependecies, ostatne veci pridu v dalsom/dalsich MR lebo som sa uz bal, ze by tu toho bolo vela, hadam som to dobre odhadol

pridali sa teraz tieto pravidla

https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.36.0/docs/rules/no-string-refs.md - s tymto som pohode ho mat zapnuty

https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.36.0/docs/rules/jsx-no-literals.md - defaultne vypnute ale nevidim tu vyhodu mat zapnute

https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.36.0/docs/rules/forward-ref-uses-ref.md - musim este pozriet

@stylistic/curly - vsetky stylistic mame vypnute takze aj toto som vypol

https://eslint.org/docs/latest/rules/no-unassigned-vars - to chceme za mna

https://eslint.org/docs/latest/rules/no-unused-private-class-members - zapnute a podla mna chceme

https://github.com/eslint/css/blob/main/docs/rules/no-invalid-at-rule-placement.md - za mna fajn, to poradia vyzera ze tak to mame pouzivat

https://github.com/eslint/css/blob/main/docs/rules/no-invalid-named-grid-areas.md za mna tiez fajn

https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/enforce-node-protocol-usage.md - ja by som zapol

https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/prefer-catch.md - za mna by som ho zapol

https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-test-id-queries.md - neviem sa vyjadrit, v default configu to nemaju zapnute

https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/prefer-user-event-setup.md - neviem sa vyjadrit, v detault configu to nemaju zapnute