### PR TITLE
Add custom sorting rule

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -754,6 +754,16 @@ export default [
       // turning this off because import is sorted by rule import/order
       'perfectionist/sort-imports': 'off',
       'perfectionist/sort-named-imports': 'off',
+      'perfectionist/sort-objects': [
+        'error',
+        {
+          type: 'unsorted',
+          useConfigurationIf: {
+            callingFunctionNamePattern:
+              '^(useInfiniteQuery|useSuspenseInfiniteQuery|infiniteQueryOptions|createFileRoute)$',
+          },
+        },
+      ],
       '@typescript-eslint/sort-type-constituents': 'off',
 
       'promise/spec-only': 'error',


### PR DESCRIPTION
Ak sa funkcia vola `useInfiniteQuery|useSuspenseInfiniteQuery|infiniteQueryOptions|createFileRoute`  tak sa nebude sortovat perfecionistom ale maju na to zapnuty vlastny rule